### PR TITLE
Discoverable service areas

### DIFF
--- a/.github/workflows/meerkat.yml
+++ b/.github/workflows/meerkat.yml
@@ -807,7 +807,7 @@ jobs:
             --set enable_dsp=true \
             --set administrator_email=jonathan@wilbur.space \
             --set administrator_email_public=true \
-            --set vendor_version='2.4.2' \
+            --set vendor_version='2.4.3' \
             --set signing_required_for_chaining=false \
             --set tcp_timeout_in_seconds=300 \
             --set min_transfer_speed_bytes_per_minute=10 \

--- a/apps/meerkat-docs/docs/advice.md
+++ b/apps/meerkat-docs/docs/advice.md
@@ -18,3 +18,10 @@
   strong authentication and TLS, so that the authentication level of chained
   requests is not downgraded as documented
   [here](./distributed.md#restrictions-that-apply-to-both).
+- It is strongly advised that you avoid using service administration anywhere in
+  the DIT except for "leaf" areas. See
+  [this](./deviations-nuances.md#hidden-service-admin-areas) for more info. In
+  addition to this problem, nothing in service administrative areas clearly
+  indicates whether an entry has no subordinates in the result set because it
+  was a part of another service admin area or because it was truly a "leaf"
+  entry. This can be unintuitive for directory users.

--- a/apps/meerkat-docs/docs/changelog-meerkat.md
+++ b/apps/meerkat-docs/docs/changelog-meerkat.md
@@ -1,5 +1,52 @@
 # Changelog for Meerkat DSA
 
+## Version 2.4.3
+
+Summary: small deviation introduced in which searches recurse one entry into
+other service administrative areas for the sake of DIT discoverability.
+
+### Changes
+
+The X.500 specifications mandate that searches are not to recurse into other
+service administrative areas, but this means that service admin points will not
+be discoverable at all via `search` operations. Since LDAP has no `list`
+operation, it also means that LDAP users will never be able to find any entry
+that lies in a different service administrative area (except by "guessing" that
+it exists).
+
+For example, if `C=US,ST=FL` is a service admin point, and a user performs a
+one-level search at `C=US`, the `ST=FL` subordinate will be hidden from the
+results entirely. The user will have no way of even finding `ST=FL` except for
+performing a `list` operation and noticing that this subordinate differs from
+the results obtained by a one-level search (since `list` is not governed by
+service administration).
+
+This version of Meerkat DSA onwards will deviate from the specification by
+recursing one entry into other service administrative areas so that the DIT is
+traversible to users. Continuing on the previous example, this means that, if a
+user performs a one-level search at `C=US`, the `ST=FL` subordinate will be
+returned. If a subtree search at `C=US` is performed, `ST=FL` will be returned
+as well, but none of its subordinates (the latter of which is technically
+correct behavior).
+
+If this is undesirable, meaning that you want Meerkat DSA to behave exactly as
+the specifications specify, fear not: this version of Meerkat DSA also
+introduces a new option, `MEERKAT_PRINCIPLED_SERVICE_ADMIN`, which, if set to
+`1`, disables this deviation. Meerkat DSA will thereby adhere strictly to the
+specifications and service admin points will be hidden from search results.
+
+:::note
+
+The above issue will be reported to the ITU working group that authors the X.500
+specifications, so it may be resolved in a future version.
+
+:::
+
+### Updating
+
+You do not have to do anything to upgrade to this version. Just update the
+Meerkat DSA version.
+
 ## Version 2.4.2
 
 **SECURITY UPDATE**

--- a/apps/meerkat-docs/docs/conformance.md
+++ b/apps/meerkat-docs/docs/conformance.md
@@ -1,7 +1,7 @@
 # Conformance
 
-In the statements below, the term "Meerkat DSA" refers to version 2.4.2 of
-Meerkat DSA, hence these statements are only claimed for version 2.4.2 of
+In the statements below, the term "Meerkat DSA" refers to version 2.4.3 of
+Meerkat DSA, hence these statements are only claimed for version 2.4.3 of
 Meerkat DSA.
 
 ## X.519 Conformance Statement

--- a/apps/meerkat-docs/docs/deviations-nuances.md
+++ b/apps/meerkat-docs/docs/deviations-nuances.md
@@ -347,6 +347,40 @@ be used to construct a `UserPwd` value (using the `encrypted` alternative), and
 that will be asserted. To reiterate, this does not violate the specifications,
 since this behavior is explicitly undefined therein.
 
+## Hidden Service Admin Areas
+
+The X.500 specifications mandate that searches are not to recurse into other
+service administrative areas, but this means that service admin points will not
+be discoverable at all via `search` operations. Since LDAP has no `list`
+operation, it also means that LDAP users will never be able to find any entry
+that lies in a different service administrative area (except by "guessing" that
+it exists).
+
+For example, if `C=US,ST=FL` is a service admin point, and a user performs a
+one-level search at `C=US`, the `ST=FL` subordinate will be hidden from the
+results entirely. The user will have no way of even finding `ST=FL` except for
+performing a `list` operation and noticing that this subordinate differs from
+the results obtained by a one-level search (since `list` is not governed by
+service administration).
+
+Meerkat DSA deviates from the specification by recursing one entry into other
+service administrative areas so that the DIT is traversible to users. Continuing
+on the previous example, this means that, if a user performs a one-level search
+at `C=US`, the `ST=FL` subordinate will be returned. If a subtree search at
+`C=US` is performed, `ST=FL` will be returned as well, but none of its
+subordinates (the latter of which is technically correct behavior).
+
+This behavior can be turned off by setting
+[`MEERKAT_PRINCIPLED_SERVICE_ADMIN`](./env.md#meerkat_principled_service_admin)
+to `1`.
+
+:::note
+
+The above issue will be reported to the ITU working group that authors the X.500
+specifications, so it may be resolved in a future version.
+
+:::
+
 ## Other Deviations
 
 There are other deviations that haven't been mentioned here. Most deviations

--- a/apps/meerkat-docs/docs/env.md
+++ b/apps/meerkat-docs/docs/env.md
@@ -951,6 +951,40 @@ other tests.
 
 :::
 
+## MEERKAT_PRINCIPLED_SERVICE_ADMIN
+
+The X.500 specifications mandate that searches are not to recurse into other
+service administrative areas, but this means that service admin points will not
+be discoverable at all via `search` operations. Since LDAP has no `list`
+operation, it also means that LDAP users will never be able to find any entry
+that lies in a different service administrative area (except by "guessing" that
+it exists).
+
+For example, if `C=US,ST=FL` is a service admin point, and a user performs a
+one-level search at `C=US`, the `ST=FL` subordinate will be hidden from the
+results entirely. The user will have no way of even finding `ST=FL` except for
+performing a `list` operation and noticing that this subordinate differs from
+the results obtained by a one-level search (since `list` is not governed by
+service administration).
+
+Meerkat DSA deviates from the specification by recursing one entry into other
+service administrative areas so that the DIT is traversible to users. Continuing
+on the previous example, this means that, if a user performs a one-level search
+at `C=US`, the `ST=FL` subordinate will be returned. If a subtree search at
+`C=US` is performed, `ST=FL` will be returned as well, but none of its
+subordinates (the latter of which is technically correct behavior).
+
+This option, if set to `1`, disables this deviation. Meerkat DSA will thereby
+adhere strictly to the specifications and service admin points will be hidden
+from search results.
+
+:::note
+
+The above issue will be reported to the ITU working group that authors the X.500
+specifications, so it may be resolved in a future version.
+
+:::
+
 ## MEERKAT_PRIVATE_KEY_ENGINE
 
 This is an open-ended string that specifies the private key engine that

--- a/apps/meerkat/src/app/ctx.ts
+++ b/apps/meerkat/src/app/ctx.ts
@@ -551,6 +551,7 @@ const config: Configuration = {
     vendorVersion: process.env.MEERKAT_VENDOR_VERSION?.length
         ? process.env.MEERKAT_VENDOR_VERSION
         : undefined,
+    principledServiceAdministration: (process.env.MEERKAT_PRINCIPLED_SERVICE_ADMIN === "1"),
     revealUserPwdEncryptedValues: (process.env.MEERKAT_REVEAL_USER_PWD === "1"),
     maxRelaxationsOrTightenings: process.env.MEERKAT_MAX_RELAXATIONS
         ? Number.parseInt(process.env.MEERKAT_MAX_RELAXATIONS, 10)

--- a/k8s/charts/meerkat-dsa/Chart.yaml
+++ b/k8s/charts/meerkat-dsa/Chart.yaml
@@ -3,7 +3,7 @@ name: meerkat-dsa
 description: X.500 Directory Server (DSA) and LDAP Server by Wildboar Software.
 type: application
 version: 2.10.0
-appVersion: 2.4.2
+appVersion: 2.4.3
 home: https://wildboarsoftware.com
 keywords:
   - directory

--- a/k8s/charts/meerkat-dsa/Chart.yaml
+++ b/k8s/charts/meerkat-dsa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: meerkat-dsa
 description: X.500 Directory Server (DSA) and LDAP Server by Wildboar Software.
 type: application
-version: 2.9.2
+version: 2.10.0
 appVersion: 2.4.2
 home: https://wildboarsoftware.com
 keywords:

--- a/k8s/charts/meerkat-dsa/templates/config.yaml
+++ b/k8s/charts/meerkat-dsa/templates/config.yaml
@@ -97,6 +97,7 @@ data:
   no_timestamp: {{ .Values.no_timestamp | ternary 1 0 | quote }}
   ob_auto_accept: {{ .Values.ob_auto_accept | ternary 1 0 | quote }}
   open_top_level: {{ .Values.open_top_level | ternary 1 0 | quote }}
+  principled_service_admin: {{ .Values.principled_service_admin | ternary 1 0 | quote }}
   {{- if .Values.private_key_engine }}
   private_key_engine: {{ .Values.private_key_engine }}
   {{- end }}

--- a/k8s/charts/meerkat-dsa/templates/deployment.yaml
+++ b/k8s/charts/meerkat-dsa/templates/deployment.yaml
@@ -515,6 +515,12 @@ spec:
                   name: {{ include "meerkat-dsa.fullname" . }}-config
                   key: open_top_level
                   optional: true
+            - name: MEERKAT_PRINCIPLED_SERVICE_ADMIN
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "meerkat-dsa.fullname" . }}-config
+                  key: principled_service_admin
+                  optional: true
             - name: MEERKAT_PRIVATE_KEY_ENGINE
               valueFrom:
                 configMapKeyRef:

--- a/k8s/charts/meerkat-dsa/values.yaml
+++ b/k8s/charts/meerkat-dsa/values.yaml
@@ -176,6 +176,7 @@ no_console: false
 no_timestamp: false
 ob_auto_accept: false
 open_top_level: false
+principled_service_admin: false
 # private_key_engine: pkcs11
 prohibit_chaining: false
 remote_pwd_time_limit: 0

--- a/libs/meerkat-types/src/lib/types.ts
+++ b/libs/meerkat-types/src/lib/types.ts
@@ -1495,6 +1495,39 @@ interface Configuration {
      */
     revealUserPwdEncryptedValues: boolean;
 
+    /**
+     * The X.500 specifications mandate that searches are not to recurse into
+     * other service administrative areas, but this means that service admin
+     * points will not be discoverable at all via `search` operations. Since
+     * LDAP has no `list` operation, it also means that LDAP users will never be
+     * able to find any entry that lies in a different service administrative
+     * area (except by "guessing" that it exists).
+     *
+     * For example, if `C=US,ST=FL` is a service admin point, and a user
+     * performs a one-level search at `C=US`, the `ST=FL` subordinate will be
+     * hidden from the results entirely. The user will have no way of even
+     * finding `ST=FL` except for performing a `list` operation and noticing
+     * that this subordinate differs from the results obtained by a one-level
+     * search (since `list` is not governed by service administration).
+     *
+     * Meerkat DSA deviates from the specification by recursing one entry into
+     * other service administrative areas so that the DIT is traversible to
+     * users. Continuing on the previous example, this means that, if a user
+     * performs a one-level search at `C=US`, the `ST=FL` subordinate will be
+     * returned. If a subtree search at `C=US` is performed, `ST=FL` will be
+     * returned as well, but none of its subordinates (the latter of which is
+     * technically correct behavior).
+     *
+     * This option, if set to `true`, disables this deviation. Meerkat DSA will
+     * thereby adhere strictly to the specifications and service admin points
+     * will be hidden from search results.
+     *
+     * NOTE: The above issue will be reported to the ITU working group that
+     * authors the X.500 specifications, so it may be resolved in a future
+     * version.
+     */
+    principledServiceAdministration: boolean;
+
     authn: AuthenticationConfiguration;
 
     log: {

--- a/pkg/control
+++ b/pkg/control
@@ -1,5 +1,5 @@
 Package: meerkat-dsa
-Version: 2.4.2
+Version: 2.4.3
 Section: database
 Priority: optional
 Architecture: i386

--- a/pkg/docker-compose.yaml
+++ b/pkg/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     labels:
       author: Wildboar Software
       app: meerkat
-      version: "2.4.2"
+      version: "2.4.3"
     ports:
       - '1389:389/tcp' # LDAP TCP Port
       - '4632:4632/tcp' # IDM Socket

--- a/pkg/meerkat-dsa.rb
+++ b/pkg/meerkat-dsa.rb
@@ -2,7 +2,7 @@ class MeerkatDSA < Formula
     desc "X.500 Directory Server (DSA) and LDAP Server by Wildboar Software"
     homepage "https://github.com/Wildboar-Software/directory"
     url "https://github.com/Wildboar-Software/directory/archive/v1.1.0.tar.gz"
-    version = "2.4.2"
+    version = "2.4.3"
     # sha256 "e86694b2e15d8d4da2477c44e584fb5e860666787d010801199a0a77bcf28a2d"
 
     def install

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: meerkat-dsa
 base: core20
-version: '2.4.2'
+version: '2.4.3'
 summary: X.500 Directory (DSA) and LDAP Server
 description: |
   Fully-featured X.500 directory server / directory system agent (DSA)


### PR DESCRIPTION

Summary: small deviation introduced in which searches recurse one entry into
other service administrative areas for the sake of DIT discoverability.

### Changes

The X.500 specifications mandate that searches are not to recurse into other
service administrative areas, but this means that service admin points will not
be discoverable at all via `search` operations. Since LDAP has no `list`
operation, it also means that LDAP users will never be able to find any entry
that lies in a different service administrative area (except by "guessing" that
it exists).

For example, if `C=US,ST=FL` is a service admin point, and a user performs a
one-level search at `C=US`, the `ST=FL` subordinate will be hidden from the
results entirely. The user will have no way of even finding `ST=FL` except for
performing a `list` operation and noticing that this subordinate differs from
the results obtained by a one-level search (since `list` is not governed by
service administration).

This version of Meerkat DSA onwards will deviate from the specification by
recursing one entry into other service administrative areas so that the DIT is
traversible to users. Continuing on the previous example, this means that, if a
user performs a one-level search at `C=US`, the `ST=FL` subordinate will be
returned. If a subtree search at `C=US` is performed, `ST=FL` will be returned
as well, but none of its subordinates (the latter of which is technically
correct behavior).

If this is undesirable, meaning that you want Meerkat DSA to behave exactly as
the specifications specify, fear not: this version of Meerkat DSA also
introduces a new option, `MEERKAT_PRINCIPLED_SERVICE_ADMIN`, which, if set to
`1`, disables this deviation. Meerkat DSA will thereby adhere strictly to the
specifications and service admin points will be hidden from search results.