### PR TITLE
Create attr certs

### DIFF
--- a/.github/workflows/meerkat.yml
+++ b/.github/workflows/meerkat.yml
@@ -807,7 +807,7 @@ jobs:
             --set enable_dsp=true \
             --set administrator_email=jonathan@wilbur.space \
             --set administrator_email_public=true \
-            --set vendor_version='2.5.0' \
+            --set vendor_version='2.6.0' \
             --set signing_required_for_chaining=false \
             --set tcp_timeout_in_seconds=300 \
             --set min_transfer_speed_bytes_per_minute=10 \

--- a/apps/meerkat-docs/docs/attr-cert.md
+++ b/apps/meerkat-docs/docs/attr-cert.md
@@ -1,0 +1,113 @@
+# Attribute Certificates
+
+## The attrCertReq Extension
+
+In Meerkat DSA, a special private extension has been added to the `read`
+operation--specifically, the `ReadArgumentData` fields--called `attrCertReq`.
+It has the following ASN.1 syntax:
+
+```asn1
+AttrCertReq ::= [PRIVATE 0] EXPLICIT SET {
+    singleUse   [0] EXPLICIT BOOLEAN OPTIONAL,
+    noAssertion [1] EXPLICIT BOOLEAN OPTIONAL,
+    ...
+}
+```
+
+If supplied in the `ReadArgumentData`, the DSA--if it recognizes this
+extension--should return an X.509 attribute certificate that it signs with its
+own signing key, containing the exact set of attributes that are returned from
+the `read` operation. In Meerkat DSA, any attribute types (meaning just the
+type and no values) that are returned will be filtered out, but this may change
+in the future and should not be considered an expected behavior: the obvious
+alternative would be to return a `Attribute`s with an empty set of values.
+
+:::note
+
+The rationale for this being supported only in the `read` operation, and not
+the `search` operation, is that it could be very computationally expensive to
+produce an attribute certificate for every search result for a large set of
+search results, and it could therefore open up Meerkat DSA to denial-of-service
+attacks whereby it is overwhelmed with requests to produce attribute
+certificates for a very large number of results. It is better for this
+extension to be reserved for `read` only.
+
+:::
+
+The `issuer` field will be populated with the DSA's AE-title, which is taken
+from the signing key in Meerkat DSA. The `holder` field will use a single
+`entityName` using the `directoryName` alternative, using an `rdnSequence` that
+contains the distinguished name of the entry targeted by the `read` operation
+(after aliases have been resolved).
+
+:::note
+
+In the future, there may be another extension to the above to use an unresolved
+alias name in the holder field, but this could be a security risk: if
+implemented incorrectly, it means that Meerkat DSA could sign attribute
+certificates that impute attributes to the wrong entity!
+
+:::
+
+The `attrCertValidityPeriod` field shall have its `notBeforeTime` set to the
+moment the request is made (or around that time), and the `notAfterTime` shall
+be set to a time that is controlled by the DSA: preferrably a very short amount
+of time in comparison to normal X.509 public key certificate durations, such as
+an hour or a day. In Meerkat DSA, the duration of the attribute certificate is
+controlled by the
+[`MEERKAT_ATTR_CERT_DURATION`](./env.md#meerkat_attr_cert_duration)
+configuration option.
+
+:::info
+
+The rationale for wanting a lower duration for attribute certificates is that,
+assuming the directory does not have availability problems, new attribute
+certificates can be requested as needed as the old ones expire: this differs
+from the issuance of public key certificates, which usually entail some ordeal
+to prove one's identity.
+
+On the other hand, if attribute certificate validities are too long, there is a
+risk of the contents of the attribute certificate being out of sync with what is
+in the directory. For example, if a person was a member in a group when an
+attribute certificate with a validity duration of five years was issued, but the
+user's membership was revoked shortly thereafter, the user would be able to
+credibly assert to third parties that the user is still in the group for the
+remaining five years! Worse yet, Meerkat DSA has no means (currently) to produce
+attribute certificate revocation lists or add attribute certificates to them,
+making it difficult to revoke them!
+
+:::
+
+If `singleUse` is `TRUE`, the DSA shall insert a `singleUse` extension into the
+attribute certificate's extensions. If `noAssertion` is `TRUE`, the DSA shall
+insert a `noAssertion` extension into the attribute certificate's extensions. A
+DSA that supports this feature may still insert these extensions unless these
+fields are explicitly set to `FALSE`, indicating that the user is requesting
+that these extensions be excluded from the attribute certificate.
+
+In general, the same authorization required to receive signed results shall
+apply to receiving an attribute certificate, since the two are so similar in
+concept.
+
+If the DSA chooses not to produce an attribute certificate (say, because of
+insufficient authorization for the requesting user) or a lack of a configured
+signing key, or fails in producing this attribute certificate, the DSA shall
+simply return a normal `read` result. If the request was honored, the bytes of
+the attribute certificate shall be added to a private extension in the
+`ReadResultData` having the following syntax:
+
+```asn1
+    attrCert  [PRIVATE 0] IMPLICIT OCTET STRING OPTIONAL
+```
+
+:::note
+
+The rationale for returning the attribute certificate as an octet string is to
+prevent a re-encoding from producing a different `toBeSigned` encoding that
+would result in an invalidated signature; in other words, its purpose is to
+preserve the exact bytes and signature value of the attribute certificate, even
+if the directory uses BER or some other set of encoding rules to transmit ASN.1
+data.
+
+:::
+

--- a/apps/meerkat-docs/docs/changelog-meerkat.md
+++ b/apps/meerkat-docs/docs/changelog-meerkat.md
@@ -1,6 +1,6 @@
 # Changelog for Meerkat DSA
 
-## Version 2.5.0
+## Version 2.6.0
 
 - Support Non-Specific Hierarchical Operational Bindings (NHOBs), which allow
   entries in multiple directories to share / compete for the same namespace.

--- a/apps/meerkat-docs/docs/conformance.md
+++ b/apps/meerkat-docs/docs/conformance.md
@@ -1,7 +1,7 @@
 # Conformance
 
-In the statements below, the term "Meerkat DSA" refers to version 2.5.0 of
-Meerkat DSA, hence these statements are only claimed for version 2.5.0 of
+In the statements below, the term "Meerkat DSA" refers to version 2.6.0 of
+Meerkat DSA, hence these statements are only claimed for version 2.6.0 of
 Meerkat DSA.
 
 ## X.519 Conformance Statement

--- a/apps/meerkat-docs/docs/env.md
+++ b/apps/meerkat-docs/docs/env.md
@@ -182,6 +182,20 @@ The file contents should look like this if you open them up in a text editor:
 This does not affect the production of signed arguments, results, or errors, nor
 does it affect TLS.
 
+## MEERKAT_ATTR_CERT_DURATION
+
+An integer indicating the number of seconds that an attribute certificate
+produced via the
+[Attribute Certificate Request extension](./attr-cert.md#the-attrcertreq-extension)
+will last. In other words, the `notBeforeTime` of the produced attribute
+certificate will be set to the current time, and the `notAfterTime` will be set
+to the current time, plus the number of seconds indicated by this configuration
+value.
+
+If set to `0` or any non-positive integer value, this feature will be disabled.
+This defaults to 3600, meaning that attribute certificates will be valid for
+one hour by default.
+
 ## MEERKAT_BIND_MIN_SLEEP_MS
 
 This is the amount of time in milliseconds (at minimum) that Meerkat DSA will

--- a/apps/meerkat-docs/docs/roadmap.md
+++ b/apps/meerkat-docs/docs/roadmap.md
@@ -4,19 +4,19 @@ We will not promise any particular schedule of delivery of features or bug fixes
 at this time. However, the very high-level roadmap for Meerkat DSA can be
 broken down to the following versions.
 
-## Version 2.6.0 - Shadowing
+## Version 2.7.0 - Shadowing
 
 This update will introduce support for the Directory Information Shadowing
 Protocol (DISP). This will allow directory information to be replicated to
 other DSAs to produce read-only copies.
 
-## Version 2.7.0 - Cross References
+## Version 2.8.0 - Cross References
 
 This update will introduce support for cross references, allowing DSAs to share
 routing information pertaining to other known DSAs. This will allow the entire
 DIT to become more discoverable and performant.
 
-## Version 2.8.0 - Schema Update ("Wildboar Schema")
+## Version 2.9.0 - Schema Update ("Wildboar Schema")
 
 This update will introduce thousands of new schema objects defined by Wildboar
 Software into the default schema. This is desirable so that X.500 directories
@@ -28,7 +28,7 @@ using a `married` auxiliary object class that permits the presence of a
 administrators everywhere to define their own equivalent object classes, thereby
 duplicating work and reducing inter-domain compatibility.
 
-## Version 2.9.0 and Beyond
+## Version 2.10.0 and Beyond
 
 Not much can be said about anything this far in the future. However, these
 features need to be introduced at some point:

--- a/apps/meerkat-docs/sidebars.js
+++ b/apps/meerkat-docs/sidebars.js
@@ -38,6 +38,7 @@ const sidebars = {
                 'advice',
                 'usage',
                 'zonal',
+                'attr-cert',
                 'telemetry',
                 'conformance',
                 'deviations-nuances',

--- a/apps/meerkat/src/app/ctx.ts
+++ b/apps/meerkat/src/app/ctx.ts
@@ -556,6 +556,9 @@ const config: Configuration = {
     maxRelaxationsOrTightenings: process.env.MEERKAT_MAX_RELAXATIONS
         ? Number.parseInt(process.env.MEERKAT_MAX_RELAXATIONS, 10)
         : 3,
+    attributeCertificateDuration: process.env.MEERKAT_ATTR_CERT_DURATION
+        ? Number.parseInt(process.env.MEERKAT_ATTR_CERT_DURATION, 10)
+        : 3600,
     authn: {
         lookupPkiPathForUncertifiedStrongAuth: (process.env.MEERKAT_LOOKUP_UNCERT_STRONG_AUTH === "1"),
         attributeCertificationPath,

--- a/apps/meerkat/src/app/distributed/read.ts
+++ b/apps/meerkat/src/app/distributed/read.ts
@@ -225,7 +225,7 @@ function createAttributeCertificate (
         serialNumber,
         new AttCertValidityPeriod(
             now,
-            addSeconds(now, 5), // TODO: Make this configurable.
+            addSeconds(now, ctx.config.attributeCertificateDuration),
         ),
         attributes,
         undefined,
@@ -703,7 +703,12 @@ async function read (
         && (ext.tagNumber === 0)
     ));
     const extensions: ASN1Element[] = [];
-    if (createAttrCertElement && signResults) {
+    const attrCertsEnabled: boolean = !!(
+        ctx.config.attributeCertificateDuration
+        && (ctx.config.attributeCertificateDuration > 0)
+        && Number.isSafeInteger(ctx.config.attributeCertificateDuration)
+    );
+    if (createAttrCertElement && signResults && attrCertsEnabled) {
         const ac_els = createAttrCertElement.inner.sequence
             .filter((el) => el.tagClass === ASN1TagClass.context);
         const single_use: BOOLEAN = ac_els.find((el) => el.tagNumber === 0)?.inner.boolean ?? FALSE;

--- a/apps/meerkat/src/app/distributed/read.ts
+++ b/apps/meerkat/src/app/distributed/read.ts
@@ -708,7 +708,7 @@ async function read (
         && (ctx.config.attributeCertificateDuration > 0)
         && Number.isSafeInteger(ctx.config.attributeCertificateDuration)
     );
-    if (createAttrCertElement && signResults && attrCertsEnabled) {
+    if (createAttrCertElement && assn?.authorizedForSignedResults && attrCertsEnabled) {
         const ac_els = createAttrCertElement.inner.sequence
             .filter((el) => el.tagClass === ASN1TagClass.context);
         const single_use: BOOLEAN = ac_els.find((el) => el.tagNumber === 0)?.inner.boolean ?? FALSE;

--- a/apps/meerkat/src/app/x500/attributesFromValues.ts
+++ b/apps/meerkat/src/app/x500/attributesFromValues.ts
@@ -36,19 +36,19 @@ function attributesFromValues (values: Value[]): Attribute[] {
                 valuesWithoutContexts.push(atav);
             }
         }
+        const vwc = valuesWithContexts
+            .map((atav) => new Attribute_valuesWithContext_Item(
+                atav.value,
+                Array.from(atav.contexts?.values() ?? []).map((context) => new Context(
+                    context.contextType,
+                    context.contextValues,
+                    context.fallback,
+                )),
+            ));
         attrs.push(new Attribute(
             atavs[0].type,
-            valuesWithoutContexts
-                .map((atav) => atav.value),
-            valuesWithContexts
-                .map((atav) => new Attribute_valuesWithContext_Item(
-                    atav.value,
-                    Array.from(atav.contexts?.values() ?? []).map((context) => new Context(
-                        context.contextType,
-                        context.contextValues,
-                        context.fallback,
-                    )),
-                )),
+            valuesWithoutContexts.map((atav) => atav.value),
+            (vwc.length > 0) ? vwc : undefined,
         ));
     }
     return attrs;

--- a/apps/meerkat/src/assets/static/conformance.md
+++ b/apps/meerkat/src/assets/static/conformance.md
@@ -1,7 +1,7 @@
 # Conformance
 
-In the statements below, the term "Meerkat DSA" refers to version 2.5.0 of
-Meerkat DSA, hence these statements are only claimed for version 2.5.0 of
+In the statements below, the term "Meerkat DSA" refers to version 2.6.0 of
+Meerkat DSA, hence these statements are only claimed for version 2.6.0 of
 Meerkat DSA.
 
 ## X.519 Conformance Statement

--- a/apps/x500-cli/package.json
+++ b/apps/x500-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wildboar/x500-cli",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "bin": {
         "x500": "./main.js"
     },

--- a/apps/x500-cli/src/commands/dap/read.ts
+++ b/apps/x500-cli/src/commands/dap/read.ts
@@ -1,6 +1,6 @@
 import type { Connection, Context } from "../../types";
-import { TRUE } from "asn1-ts";
-import { DER } from "asn1-ts/dist/node/functional";
+import { ASN1Construction, ASN1Element, ASN1TagClass, DERElement, ObjectIdentifier, TRUE, TRUE_BIT } from "asn1-ts";
+import { DER, _encodeBoolean } from "asn1-ts/dist/node/functional";
 import {
     read,
 } from "@wildboar/x500/src/lib/modules/DirectoryAbstractService/read.oa";
@@ -21,7 +21,6 @@ import {
 import getOptionallyProtectedValue from "@wildboar/x500/src/lib/utils/getOptionallyProtectedValue";
 import destringifyDN from "../../utils/destringifyDN";
 import stringifyDN from "../../utils/stringifyDN";
-import selectAll from "../../utils/selectAll";
 import printEntryInformation from "../../printers/EntryInformation";
 import {
     AttributeValueAssertion,
@@ -34,6 +33,39 @@ import {
     SecurityParameters,
 } from "@wildboar/x500/src/lib/modules/DirectoryAbstractService/SecurityParameters.ta";
 import { EOL } from "node:os";
+import {
+    EntryInformationSelection,
+} from "@wildboar/x500/src/lib/modules/DirectoryAbstractService/EntryInformationSelection.ta";
+import * as sco from "@wildboar/x500/src/lib/modules/DirectoryAbstractService/ServiceControlOptions.ta";
+import { ServiceControls } from "@wildboar/x500/src/lib/modules/DirectoryAbstractService/ServiceControls.ta";
+import {
+    ServiceControls_priority_low,
+    ServiceControls_priority_medium,
+    ServiceControls_priority_high,
+} from "@wildboar/x500/src/lib/modules/DirectoryAbstractService/ServiceControls-priority.ta";
+import {
+    ServiceControls_scopeOfReferral_country,
+    ServiceControls_scopeOfReferral_dmd,
+} from "@wildboar/x500/src/lib/modules/DirectoryAbstractService/ServiceControls-scopeOfReferral.ta";
+import * as fs from "node:fs/promises";
+import { PEMObject } from "pem-ts";
+
+function priorityFromString (str: string): ServiceControls["priority"] {
+    switch (str.trim().toLowerCase()) {
+        case ("low"): return ServiceControls_priority_low;
+        case ("medium"): return ServiceControls_priority_medium;
+        case ("high"): return ServiceControls_priority_high;
+        default: return ServiceControls_priority_medium;
+    }
+}
+
+function scopeOfReferralFromString (str: string): ServiceControls["scopeOfReferral"] {
+    switch (str.trim().toLowerCase()) {
+        case ("dmd"): return ServiceControls_scopeOfReferral_dmd;
+        case ("country"): return ServiceControls_scopeOfReferral_country;
+        default: return undefined;
+    }
+}
 
 export
 async function do_read (
@@ -42,14 +74,118 @@ async function do_read (
     argv: any,
 ): Promise<void> {
     const objectName: DistinguishedName = destringifyDN(ctx, argv.object);
+    const eis = new EntryInformationSelection(
+        argv.userAttribute
+            ? {
+                select: argv.userAttribute.map(ObjectIdentifier.fromString),
+            }
+            : undefined,
+        argv.typesOnly,
+        argv.extraAttribute
+            ? {
+                select: argv.extraAttribute.map(ObjectIdentifier.fromString),
+            }
+            : undefined,
+        argv.allContexts
+            ? {
+                allContexts: null,
+            }
+            : undefined,
+        argv.returnContexts,
+    );
+    const serviceControlOptions: sco.ServiceControlOptions = new Uint8ClampedArray(15);
+    if (argv.preferChaining) {
+        serviceControlOptions[sco.ServiceControlOptions_preferChaining] = TRUE_BIT;
+    }
+    if (argv.chainingProhibited) {
+        serviceControlOptions[sco.ServiceControlOptions_chainingProhibited] = TRUE_BIT;
+    }
+    if (argv.localScope) {
+        serviceControlOptions[sco.ServiceControlOptions_localScope] = TRUE_BIT;
+    }
+    if (argv.dontUseCopy) {
+        serviceControlOptions[sco.ServiceControlOptions_dontUseCopy] = TRUE_BIT;
+    }
+    if (argv.dontDereferenceAliases) {
+        serviceControlOptions[sco.ServiceControlOptions_dontDereferenceAliases] = TRUE_BIT;
+    }
+    if (argv.subentries) {
+        serviceControlOptions[sco.ServiceControlOptions_subentries] = TRUE_BIT;
+    }
+    if (argv.copyShallDo) {
+        serviceControlOptions[sco.ServiceControlOptions_copyShallDo] = TRUE_BIT;
+    }
+    if (argv.partialNameResolution) {
+        serviceControlOptions[sco.ServiceControlOptions_partialNameResolution] = TRUE_BIT;
+    }
+    if (argv.manageDSAIT) {
+        serviceControlOptions[sco.ServiceControlOptions_manageDSAIT] = TRUE_BIT;
+    }
+    if (argv.noSubtypeMatch) {
+        serviceControlOptions[sco.ServiceControlOptions_noSubtypeMatch] = TRUE_BIT;
+    }
+    if (argv.noSubtypeSelection) {
+        serviceControlOptions[sco.ServiceControlOptions_noSubtypeSelection] = TRUE_BIT;
+    }
+    if (argv.countFamily) {
+        serviceControlOptions[sco.ServiceControlOptions_countFamily] = TRUE_BIT;
+    }
+    if (argv.dontSelectFriends) {
+        serviceControlOptions[sco.ServiceControlOptions_dontSelectFriends] = TRUE_BIT;
+    }
+    if (argv.dontMatchFriends) {
+        serviceControlOptions[sco.ServiceControlOptions_dontMatchFriends] = TRUE_BIT;
+    }
+    if (argv.allowWriteableCopy) {
+        serviceControlOptions[sco.ServiceControlOptions_allowWriteableCopy] = TRUE_BIT;
+    }
+    const serviceControls = new ServiceControls(
+        serviceControlOptions,
+        argv.priority
+            ? priorityFromString(argv.priority)
+            : undefined,
+        argv.timeLimit,
+        argv.sizeLimit,
+        argv.scopeOfReferral
+            ? scopeOfReferralFromString(argv.scopeOfReferral)
+            : undefined,
+        argv.attributeSizeLimit,
+        undefined, // FIXME:
+        argv.serviceType
+            ? ObjectIdentifier.fromString(argv.serviceType)
+            : undefined,
+        argv.userClass,
+    );
+    const extensions: ASN1Element[] = [];
+    if (argv.attrCert) {
+        const attrCert = new DERElement();
+        attrCert.tagClass = ASN1TagClass.private;
+        attrCert.construction = ASN1Construction.constructed;
+        attrCert.tagNumber = 0;
+        attrCert.value = DERElement.fromSet([
+            new DERElement(
+                ASN1TagClass.context,
+                ASN1Construction.constructed,
+                0,
+                _encodeBoolean(argv.singleUse, DER),
+            ),
+            new DERElement(
+                ASN1TagClass.context,
+                ASN1Construction.constructed,
+                1,
+                _encodeBoolean(argv.noAssertion, DER),
+            ),
+        ]).toBytes();
+        extensions.push(attrCert);
+    }
     const reqData: ReadArgumentData = new ReadArgumentData(
         {
             rdnSequence: objectName,
         },
-        selectAll,
-        TRUE,
-        [],
-        undefined,
+        eis,
+        argv.modifyRights,
+        extensions,
+        serviceControls,
         new SecurityParameters(
             undefined,
             undefined,
@@ -59,16 +195,6 @@ async function do_read (
             undefined,
             ProtectionRequest_signed,
         ),
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
     );
     const arg: ReadArgument = {
         unsigned: reqData,
@@ -130,6 +256,15 @@ async function do_read (
                 console.log("Not understood item in modifyRights.");
             }
         })
+    }
+    const attrCertBytes = resData._unrecognizedExtensionsList.find((ext) => (
+        (ext.tagClass === ASN1TagClass.private)
+        && (ext.tagNumber === 0)
+    ))?.octetString;
+    if (argv.attrCert && attrCertBytes) {
+        const pem = new PEMObject("ATTRIBUTE CERTIFICATE", attrCertBytes);
+        await fs.writeFile(argv.attrCert, pem.encoded);
+        console.log(`Saved attribute certificate to ${argv.attrCert}.`);
     }
 }
 

--- a/apps/x500-cli/src/main.ts
+++ b/apps/x500-cli/src/main.ts
@@ -49,6 +49,7 @@ import dap_mod_become_pwdsub from "./yargs/dap_mod_become_pwdsub";
 import dap_mod_become_subschema from "./yargs/dap_mod_become_subschema";
 import dap_mod_become_svcsub from "./yargs/dap_mod_become_svcsub";
 import dap_mod_become_acsub from "./yargs/dap_mod_become_acsub";
+import dap_read from "./yargs/dap_read";
 import dap_search from "./yargs/dap_search";
 import do_seedCountries from "./commands/util/seed-countries";
 import bind from "./net/bind";
@@ -228,16 +229,7 @@ async function main () {
                         await do_modifyDN(ctx, connection, argv);
                         await connection.close();
                     })
-                    .command("read <object>", "Read an entry", (readYargs) => {
-                        return readYargs
-                            .positional("object", {
-                                describe: "The object to read",
-                            });
-                    }, async (argv) => {
-                        const connection = await bind(ctx, argv);
-                        await do_read(ctx, connection, argv);
-                        await connection.close();
-                    })
+                    .command(dap_read(ctx))
                     .command("remove <object>", "Remove an entry", (removeYargs) => {
                         return removeYargs
                             .positional("object", {

--- a/apps/x500-cli/src/yargs/dap_read.ts
+++ b/apps/x500-cli/src/yargs/dap_read.ts
@@ -1,0 +1,152 @@
+import type { Context } from "../types";
+import type { CommandModule } from "yargs";
+import bind from "../net/bind";
+import read from "../commands/dap/read";
+
+export
+function create (ctx: Context): CommandModule {
+    return {
+        command: "read <object>",
+        describe: "Read an entry",
+        builder: (y) => {
+            return y
+                .positional("object", {
+                    type: "string",
+                    describe: "The entry whose subordinates are to be listed",
+                })
+                .option("modifyRights", {
+                    alias: "m",
+                    type: "boolean",
+                    describe: "Whether to request a listing of modification rights to this entry",
+                })
+                .option("userAttribute", {
+                    alias: "u",
+                    type: "array",
+                    describe: "Dot-delimited object identifier of attribute type to select",
+                })
+                .option("extraAttribute", {
+                    alias: "x",
+                    type: "array",
+                    describe: "Dot-delimited object identifier of operational attribute type to select",
+                })
+                .option("typesOnly", {
+                    alias: "t",
+                    type: "boolean",
+                    describe: "Whether to return only attribute types (no attribute values)",
+                })
+                .option("allContexts", {
+                    type: "boolean",
+                    describe: "Whether to ignore context assertion defaults",
+                })
+                .option("returnContexts", {
+                    alias: "c",
+                    type: "boolean",
+                    describe: "Whether to return contexts with values",
+                })
+                .option("attrCert", {
+                    type: "string",
+                    describe: "Request an attribute certificate (only works on some DSAs)",
+                })
+                .option("singleUse", {
+                    type: "boolean",
+                    describe: "Whether the attribute cert should have the singleUse extension",
+                    demandOption: "attrCert",
+                    default: false,
+                })
+                .option("noAssertion", {
+                    type: "boolean",
+                    describe: "Whether the attribute cert should have the noAssertion extension",
+                    demandOption: "attrCert",
+                    default: false,
+                })
+
+                // Service controls
+                .option("priority", {
+                    type: "string",
+                    choices: [
+                        "low",
+                        "medium",
+                        "high",
+                    ],
+                    description: "The priority of the request",
+                })
+                .option("timeLimit", {
+                    type: "number",
+                    description: "How many seconds the request should be permitted to last before being aborted",
+                })
+                .option("sizeLimit", {
+                    type: "number",
+                    description: "The maximum number of entries the request may return",
+                })
+                .option("scopeOfReferral", {
+                    type: "string",
+                    choices: [
+                        "dmd",
+                        "country",
+                    ],
+                    description: "The subset of referrals permitted to be returned",
+                })
+                .option("attributeSizeLimit", {
+                    type: "number",
+                    description: "The maximum permitted size of attributes to be returned"
+                })
+
+                // ServiceControlOptions
+                .option("preferChaining", {
+                    type: "boolean",
+                    description: "Whether to ask the DSA to chain the operation to other DSAs rather than returning referrals",
+                })
+                .option("chainingProhibited", {
+                    type: "boolean",
+                    description: "Whether to explicitly prohibit chaining to other DSAs",
+                })
+                .option("localScope", {
+                    type: "boolean",
+                    description: "Whether the operation should be limited to a local scope",
+                })
+                .option("dontUseCopy", {
+                    type: "boolean",
+                    description: "Whether to permit the use of shadow DSEs or writeable copies.",
+                })
+                .option("dontDereferenceAliases", {
+                    type: "boolean",
+                    description: "Whether to prohibit dereferencing aliases",
+                })
+                .option("subentries", {
+                    type: "boolean",
+                    description: "Whether to only display subentries",
+                })
+                .option("copyShallDo", {
+                    type: "boolean",
+                    description: "Whether the DSA shall use a shadow DSE even if it is only able to partially satisfy the query",
+                })
+                .option("partialNameResolution", {
+                    type: "boolean",
+                    description: "Whether the DSA shall settle for the highest found entry if the target entry is not found.",
+                })
+                .option("manageDSAIT", {
+                    type: "boolean",
+                    description: "Whether the request shall break the illusion of a single unified directory and permit modification of operational attributes and knowledge references.",
+                })
+                .option("noSubtypeSelection", {
+                    type: "boolean",
+                    description: "Whether attribute subtypes shall not be selected",
+                })
+                .option("dontSelectFriends", {
+                    type: "boolean",
+                    description: "Whether friend attributes should not be selected",
+                })
+
+                .strict()
+                .help()
+                ;
+        },
+        handler: async (argv) => {
+            const connection = await bind(ctx, argv);
+            await read(ctx, connection, argv);
+            await connection.close();
+        },
+    };
+}
+
+export default create;

--- a/k8s/charts/meerkat-dsa/Chart.yaml
+++ b/k8s/charts/meerkat-dsa/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meerkat-dsa
 description: X.500 Directory Server (DSA) and LDAP Server by Wildboar Software.
 type: application
-version: 2.11.0
-appVersion: 2.5.0
+version: 2.12.0
+appVersion: 2.6.0
 home: https://wildboarsoftware.com
 keywords:
   - directory

--- a/k8s/charts/meerkat-dsa/templates/config.yaml
+++ b/k8s/charts/meerkat-dsa/templates/config.yaml
@@ -9,6 +9,7 @@ data:
   administrator_email: {{ .Values.administrator_email }}
   {{- end }}
   administrator_email_public: {{ .Values.administrator_email_public | default false | ternary 1 0 | quote }}
+  attr_cert_duration: {{ .Values.attr_cert_duration | default 3600 | quote }}
   bind_min_sleep_ms: {{ .Values.bind_min_sleep_ms | quote }}
   bind_sleep_range_ms: {{ .Values.bind_sleep_range_ms | quote }}
   bulk_insert_mode: {{ .Values.bulk_insert_mode | ternary 1 0 | quote }}

--- a/k8s/charts/meerkat-dsa/templates/deployment.yaml
+++ b/k8s/charts/meerkat-dsa/templates/deployment.yaml
@@ -125,6 +125,12 @@ spec:
                   name: {{ include "meerkat-dsa.fullname" . }}-config
                   key: administrator_email_public
                   optional: true
+            - name: MEERKAT_ATTR_CERT_DURATION
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "meerkat-dsa.fullname" . }}-config
+                  key: attr_cert_duration
+                  optional: true
             - name: MEERKAT_BIND_MIN_SLEEP_MS
               valueFrom:
                 configMapKeyRef:

--- a/k8s/charts/meerkat-dsa/values.yaml
+++ b/k8s/charts/meerkat-dsa/values.yaml
@@ -105,6 +105,8 @@ databaseSecretName: meerkat-database-secret
 
 # administrator_email: jonathan@wilbur.space
 # administrator_email_public: true
+# TODO: attr cert chain file?
+attr_cert_duration: 3600
 bind_min_sleep_ms: 1000
 bind_sleep_range_ms: 3000
 bulk_insert_mode: false

--- a/libs/meerkat-types/src/lib/types.ts
+++ b/libs/meerkat-types/src/lib/types.ts
@@ -2087,6 +2087,19 @@ interface Configuration {
      */
     maxRelaxationsOrTightenings: number;
 
+    /**
+     * An integer indicating the number of seconds that an attribute certificate
+     * produced via the Attribute Certificate Request extension
+     * will last. In other words, the `notBeforeTime` of the produced attribute
+     * certificate will be set to the current time, and the `notAfterTime` will
+     * be set to the current time, plus the number of seconds indicated by this
+     * configuration value.
+     *
+     * If set to `0` or any non-positive integer value, this feature will be
+     * disabled.
+     */
+    attributeCertificateDuration: number;
+
     /** Directory Access Protocol (DAP) options. */
     dap: {
 

--- a/pkg/control
+++ b/pkg/control
@@ -1,5 +1,5 @@
 Package: meerkat-dsa
-Version: 2.5.0
+Version: 2.6.0
 Section: database
 Priority: optional
 Architecture: i386

--- a/pkg/docker-compose.yaml
+++ b/pkg/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     labels:
       author: Wildboar Software
       app: meerkat
-      version: "2.5.0"
+      version: "2.6.0"
     ports:
       - '1389:389/tcp' # LDAP TCP Port
       - '4632:4632/tcp' # IDM Socket

--- a/pkg/meerkat-dsa.rb
+++ b/pkg/meerkat-dsa.rb
@@ -2,7 +2,7 @@ class MeerkatDSA < Formula
     desc "X.500 Directory Server (DSA) and LDAP Server by Wildboar Software"
     homepage "https://github.com/Wildboar-Software/directory"
     url "https://github.com/Wildboar-Software/directory/archive/v1.1.0.tar.gz"
-    version = "2.5.0"
+    version = "2.6.0"
     # sha256 "e86694b2e15d8d4da2477c44e584fb5e860666787d010801199a0a77bcf28a2d"
 
     def install

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: meerkat-dsa
 base: core20
-version: '2.5.0'
+version: '2.6.0'
 summary: X.500 Directory (DSA) and LDAP Server
 description: |
   Fully-featured X.500 directory server / directory system agent (DSA)


### PR DESCRIPTION
This feature allows you to create attribute certificates from a `read` operation.