### PR TITLE
Cache schema between entry additions

### DIFF
--- a/.github/workflows/meerkat.yml
+++ b/.github/workflows/meerkat.yml
@@ -808,7 +808,7 @@ jobs:
             --set enable_dsp=true \
             --set administrator_email=jonathan@wilbur.space \
             --set administrator_email_public=true \
-            --set vendor_version='3.2.2' \
+            --set vendor_version='3.2.3' \
             --set signing_required_for_chaining=false \
             --set tcp_timeout_in_seconds=300 \
             --set min_transfer_speed_bytes_per_minute=10 \

--- a/apps/create-test-dit/src/app/create-us.ts
+++ b/apps/create-test-dit/src/app/create-us.ts
@@ -960,7 +960,7 @@ async function seedUS (
     const peepantsGang: DistinguishedName[] = [];
     const newEntryArgs: [cn: string, arg: AddEntryArgument][] = [];
     // Create random people
-    for (let i = 1; i < 1000; i++) {
+    for (let i = 1; i < 10_000; i++) {
         // TODO: pgpKeyInfo
         // TODO: simpleSecurityObject
         // TODO: uidObject
@@ -1355,7 +1355,7 @@ async function seedUS (
         newEntryArgs,
         ([cn, arg]) => idempotentAddEntry(ctx, conn, `C=US,ST=FL,L=HIL,L=Tampa,L=Westchase,CN=${cn}`, arg),
         {
-            concurrency: 10,
+            concurrency: 20,
         },
     );
 

--- a/apps/meerkat-docs/docs/changelog-meerkat.md
+++ b/apps/meerkat-docs/docs/changelog-meerkat.md
@@ -1,5 +1,10 @@
 # Changelog for Meerkat DSA
 
+## Version 3.2.3
+
+This version improves the speed of inserting new entries by about 10% by caching
+schema between invocations of the `addEntry` operation.
+
 ## Version 3.2.2
 
 This version **dramatically** improves the performance of the DSA for `search`

--- a/apps/meerkat-docs/docs/conformance.md
+++ b/apps/meerkat-docs/docs/conformance.md
@@ -1,7 +1,7 @@
 # Conformance
 
-In the statements below, the term "Meerkat DSA" refers to version 3.2.2 of
-Meerkat DSA, hence these statements are only claimed for version 3.2.2 of
+In the statements below, the term "Meerkat DSA" refers to version 3.2.3 of
+Meerkat DSA, hence these statements are only claimed for version 3.2.3 of
 Meerkat DSA.
 
 ## X.519 Conformance Statement

--- a/apps/meerkat/package.json
+++ b/apps/meerkat/package.json
@@ -12,7 +12,7 @@
             "url": "https://github.com/JonathanWilbur"
         }
     ],
-    "version": "3.2.2",
+    "version": "3.2.3",
     "license": "MIT",
     "bin": {
         "meerkat": "./main.js"

--- a/apps/meerkat/src/app/database/drivers/dITContentRules.ts
+++ b/apps/meerkat/src/app/database/drivers/dITContentRules.ts
@@ -15,7 +15,6 @@ import { DER } from "asn1-ts/dist/node/functional";
 import { dITContentRules } from "@wildboar/x500/src/lib/modules/SchemaAdministration/dITContentRules.oa";
 import { subschema } from "@wildboar/x500/src/lib/modules/SchemaAdministration/subschema.oa";
 import directoryStringToString from "@wildboar/x500/src/lib/stringifiers/directoryStringToString";
-import readDITContentRuleDescriptions from "../readers/readDITContentRuleDescriptions";
 
 const SUBSCHEMA: string = subschema["&id"].toString();
 
@@ -27,11 +26,10 @@ const readValues: SpecialAttributeDatabaseReader = async (
     if (!vertex.dse.subentry || !vertex.dse.objectClass.has(SUBSCHEMA)) {
         return [];
     }
-    return (await readDITContentRuleDescriptions(ctx, vertex.dse.id))
-        .map((value) => ({
-            type: dITContentRules["&id"],
-            value: dITContentRules.encoderFor["&Type"]!(value, DER),
-        }));
+    return vertex.dse.subentry.ditContentRules?.map((cr) => ({
+        type: dITContentRules["&id"],
+        value: dITContentRules.encoderFor["&Type"]!(cr, DER),
+    })) ?? [];
 };
 
 export

--- a/apps/meerkat/src/app/database/drivers/dITContextUse.ts
+++ b/apps/meerkat/src/app/database/drivers/dITContextUse.ts
@@ -15,7 +15,6 @@ import { DER } from "asn1-ts/dist/node/functional";
 import { dITContextUse } from "@wildboar/x500/src/lib/modules/SchemaAdministration/dITContextUse.oa";
 import { subschema } from "@wildboar/x500/src/lib/modules/SchemaAdministration/subschema.oa";
 import directoryStringToString from "@wildboar/x500/src/lib/stringifiers/directoryStringToString";
-import readDITContextUseDescriptions from "../readers/readDITContextUseDescriptions";
 
 const SUBSCHEMA: string = subschema["&id"].toString();
 
@@ -27,11 +26,10 @@ const readValues: SpecialAttributeDatabaseReader = async (
     if (!vertex.dse.subentry || !vertex.dse.objectClass.has(SUBSCHEMA)) {
         return [];
     }
-    return (await readDITContextUseDescriptions(ctx, vertex.dse.id))
-        .map((value) => ({
-            type: dITContextUse["&id"],
-            value: dITContextUse.encoderFor["&Type"]!(value, DER),
-        }));
+    return vertex.dse.subentry.ditContextUse?.map((cur) => ({
+        type: dITContextUse["&id"],
+        value: dITContextUse.encoderFor["&Type"]!(cur, DER),
+    })) ?? [];
 };
 
 export

--- a/apps/meerkat/src/app/database/drivers/dITStructureRules.ts
+++ b/apps/meerkat/src/app/database/drivers/dITStructureRules.ts
@@ -15,7 +15,6 @@ import { DER } from "asn1-ts/dist/node/functional";
 import { dITStructureRules } from "@wildboar/x500/src/lib/modules/SchemaAdministration/dITStructureRules.oa";
 import { subschema } from "@wildboar/x500/src/lib/modules/SchemaAdministration/subschema.oa";
 import directoryStringToString from "@wildboar/x500/src/lib/stringifiers/directoryStringToString";
-import readDITStructureRuleDescriptions from "../readers/readDITStructureRuleDescriptions";
 import {
     id_ar_subschemaAdminSpecificArea,
 } from "@wildboar/x500/src/lib/modules/InformationFramework/id-ar-subschemaAdminSpecificArea.va";
@@ -32,11 +31,10 @@ const readValues: SpecialAttributeDatabaseReader = async (
     if (!vertex.dse.subentry || !vertex.dse.objectClass.has(SUBSCHEMA)) {
         return [];
     }
-    return (await readDITStructureRuleDescriptions(ctx, vertex.dse.id))
-        .map((value) => ({
-            type: dITStructureRules["&id"],
-            value: dITStructureRules.encoderFor["&Type"]!(value, DER),
-        }));
+    return vertex.dse.subentry.ditStructureRules?.map((dsr) => ({
+        type: dITStructureRules["&id"],
+        value: dITStructureRules.encoderFor["&Type"]!(dsr, DER),
+    })) ?? [];
 };
 
 export

--- a/apps/meerkat/src/app/database/drivers/matchingRuleUse.ts
+++ b/apps/meerkat/src/app/database/drivers/matchingRuleUse.ts
@@ -15,7 +15,6 @@ import { DER } from "asn1-ts/dist/node/functional";
 import { matchingRuleUse } from "@wildboar/x500/src/lib/modules/SchemaAdministration/matchingRuleUse.oa";
 import { subschema } from "@wildboar/x500/src/lib/modules/SchemaAdministration/subschema.oa";
 import directoryStringToString from "@wildboar/x500/src/lib/stringifiers/directoryStringToString";
-import readMatchingRuleUseDescriptions from "../readers/readMatchingRuleUseDescriptions";
 
 const SUBSCHEMA: string = subschema["&id"].toString();
 
@@ -27,11 +26,10 @@ const readValues: SpecialAttributeDatabaseReader = async (
     if (!vertex.dse.subentry || !vertex.dse.objectClass.has(SUBSCHEMA)) {
         return [];
     }
-    return (await readMatchingRuleUseDescriptions(ctx, vertex.dse.id))
-        .map((value) => ({
-            type: matchingRuleUse["&id"],
-            value: matchingRuleUse.encoderFor["&Type"]!(value, DER),
-        }));
+    return vertex.dse.subentry.matchingRuleUse?.map((mru) => ({
+        type: matchingRuleUse["&id"],
+        value: matchingRuleUse.encoderFor["&Type"]!(mru, DER),
+    })) ?? [];
 };
 
 export

--- a/apps/meerkat/src/assets/static/conformance.md
+++ b/apps/meerkat/src/assets/static/conformance.md
@@ -1,7 +1,7 @@
 # Conformance
 
-In the statements below, the term "Meerkat DSA" refers to version 3.2.2 of
-Meerkat DSA, hence these statements are only claimed for version 3.2.2 of
+In the statements below, the term "Meerkat DSA" refers to version 3.2.3 of
+Meerkat DSA, hence these statements are only claimed for version 3.2.3 of
 Meerkat DSA.
 
 ## X.519 Conformance Statement

--- a/k8s/charts/meerkat-dsa/Chart.yaml
+++ b/k8s/charts/meerkat-dsa/Chart.yaml
@@ -3,7 +3,7 @@ name: meerkat-dsa
 description: X.500 Directory Server (DSA) and LDAP Server by Wildboar Software.
 type: application
 version: 2.17.2
-appVersion: 3.2.2
+appVersion: 3.2.3
 home: https://wildboarsoftware.com
 keywords:
   - directory

--- a/pkg/control
+++ b/pkg/control
@@ -1,5 +1,5 @@
 Package: meerkat-dsa
-Version: 3.2.2
+Version: 3.2.3
 Section: database
 Priority: optional
 Architecture: i386

--- a/pkg/docker-compose.yaml
+++ b/pkg/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     labels:
       author: Wildboar Software
       app: meerkat
-      version: "3.2.2"
+      version: "3.2.3"
     ports:
       - '1389:389/tcp' # LDAP TCP Port
       - '4632:4632/tcp' # IDM Socket

--- a/pkg/meerkat-dsa.rb
+++ b/pkg/meerkat-dsa.rb
@@ -2,7 +2,7 @@ class MeerkatDSA < Formula
     desc "X.500 Directory Server (DSA) and LDAP Server by Wildboar Software"
     homepage "https://github.com/Wildboar-Software/directory"
     url "https://github.com/Wildboar-Software/directory/archive/v1.1.0.tar.gz"
-    version = "3.2.2"
+    version = "3.2.3"
     # sha256 "e86694b2e15d8d4da2477c44e584fb5e860666787d010801199a0a77bcf28a2d"
 
     def install

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: meerkat-dsa
 base: core20
-version: '3.2.2'
+version: '3.2.3'
 summary: X.500 Directory (DSA) and LDAP Server
 description: |
   Fully-featured X.500 directory server / directory system agent (DSA)


### PR DESCRIPTION
This version improves the speed of inserting new entries by about 10% by caching
schema between invocations of the `addEntry` operation.