### PR TITLE
More subentry caching

### DIFF
--- a/.github/workflows/meerkat.yml
+++ b/.github/workflows/meerkat.yml
@@ -808,7 +808,7 @@ jobs:
             --set enable_dsp=true \
             --set administrator_email=jonathan@wilbur.space \
             --set administrator_email_public=true \
-            --set vendor_version='3.2.3' \
+            --set vendor_version='3.2.4' \
             --set signing_required_for_chaining=false \
             --set tcp_timeout_in_seconds=300 \
             --set min_transfer_speed_bytes_per_minute=10 \

--- a/apps/meerkat-docs/docs/changelog-meerkat.md
+++ b/apps/meerkat-docs/docs/changelog-meerkat.md
@@ -1,5 +1,10 @@
 # Changelog for Meerkat DSA
 
+## Version 3.2.4
+
+This version _doubles_ the speed of inserting new entries by caching
+subschema subentries between invocations of the `addEntry` operation.
+
 ## Version 3.2.3
 
 This version improves the speed of inserting new entries by about 10% by caching

--- a/apps/meerkat/package.json
+++ b/apps/meerkat/package.json
@@ -12,7 +12,7 @@
             "url": "https://github.com/JonathanWilbur"
         }
     ],
-    "version": "3.2.3",
+    "version": "3.2.4",
     "license": "MIT",
     "bin": {
         "meerkat": "./main.js"

--- a/apps/meerkat/src/app/distributed/addEntry.ts
+++ b/apps/meerkat/src/app/distributed/addEntry.ts
@@ -394,10 +394,6 @@ async function addEntry (
      * subentry by checking that the `subentry` object class is present.
      */
     const isSubentry: boolean = objectClassesIndex.has(id_sc_subentry.toString());
-    if (isSubentry) {
-        assn.subentriesCache.delete(immediateSuperior.dse.id);
-    }
-
     const isSubschemaSubentry: boolean = isSubentry && objectClasses.some((oc) => oc.isEqualTo(subschema["&id"]));
     const relevantSubentries: Vertex[] = ctx.config.bulkInsertMode
         ? []
@@ -1661,6 +1657,9 @@ async function addEntry (
         structuralObjectClass: structuralObjectClass.toString(),
         cp,
     }, data.entry, user?.dn);
+    if (isSubentry) {
+        assn.subentriesCache.delete(immediateSuperior.dse.id);
+    }
     if (!ctx.config.bulkInsertMode) {
         ctx.log.debug(ctx.i18n.t("log:add_entry", {
             aid: assn.id,

--- a/apps/meerkat/src/app/distributed/addEntry.ts
+++ b/apps/meerkat/src/app/distributed/addEntry.ts
@@ -376,6 +376,7 @@ async function addEntry (
         state.chainingArguments.aliasDereferenced ?? ChainingArguments._default_value_for_aliasDereferenced,
         manageDSAIT,
         state.invokeId,
+        assn.subentriesCache,
         // If this entry is going to wind up in another DSA, it is up to that
         // DSA to determine if any schema is unrecognized.
         Boolean(data.targetSystem),
@@ -393,6 +394,9 @@ async function addEntry (
      * subentry by checking that the `subentry` object class is present.
      */
     const isSubentry: boolean = objectClassesIndex.has(id_sc_subentry.toString());
+    if (isSubentry) {
+        assn.subentriesCache.delete(immediateSuperior.dse.id);
+    }
 
     const isSubschemaSubentry: boolean = isSubentry && objectClasses.some((oc) => oc.isEqualTo(subschema["&id"]));
     const relevantSubentries: Vertex[] = ctx.config.bulkInsertMode

--- a/apps/meerkat/src/app/distributed/modifyDN.ts
+++ b/apps/meerkat/src/app/distributed/modifyDN.ts
@@ -1351,7 +1351,7 @@ async function modifyDN (
     let newGoverningStructureRule: INTEGER | undefined;
     const schemaSubentry = target.dse.subentry // Schema rules only apply to entries.
         ? undefined
-        : await getSubschemaSubentry(ctx, superior);
+        : await getSubschemaSubentry(ctx, superior, new Map());
     if (!isSubentry && schemaSubentry) { // Schema rules only apply to entries.
         const structuralRules = (schemaSubentry.dse.subentry?.ditStructureRules ?? [])
             .filter((rule) => ( // TODO: You can do better than this ugly code.

--- a/apps/meerkat/src/app/distributed/modifyEntry.ts
+++ b/apps/meerkat/src/app/distributed/modifyEntry.ts
@@ -2719,7 +2719,7 @@ async function modifyEntry (
     const precludedAttributes: Set<IndexableOID> = new Set();
     const permittedAuxiliaries: Set<IndexableOID> = new Set();
     const contextRulesIndex: ContextRulesIndex = new Map();
-    const subschemaSubentry = await getSubschemaSubentry(ctx, target);
+    const subschemaSubentry = await getSubschemaSubentry(ctx, target, new Map());
     if (!ctx.config.bulkInsertMode && subschemaSubentry && !isSubentry) {
         const contentRule = (subschemaSubentry.dse.subentry?.ditContentRules ?? [])
             // .find(), because there should only be one per SOC.

--- a/apps/meerkat/src/app/dop/establish/becomeSubordinate.ts
+++ b/apps/meerkat/src/app/dop/establish/becomeSubordinate.ts
@@ -65,7 +65,7 @@ async function createContextPrefixEntry (
     // If the governing structure rule was not present in the context prefix
     // vertex, we have to calculate it.
     if (last && !attributes.some((attr) => attr.type_.isEqualTo(governingStructureRule["&id"]))) {
-        const schemaSubentry = await getSubschemaSubentry(ctx, currentRoot);
+        const schemaSubentry = await getSubschemaSubentry(ctx, currentRoot, new Map());
         // TODO: This next section was copy-pasted a lot. Refactor.
         if (schemaSubentry && (typeof currentRoot.dse.governingStructureRule === "number")) {
             if (!schemaSubentry?.dse.subentry) {
@@ -265,7 +265,7 @@ async function becomeSubordinate (
     // If the governing structure rule for the new CP was not supplied in the
     // HOB attributes, we have to calculate it.
     if (cp_gsr === undefined) {
-        const schemaSubentry = await getSubschemaSubentry(ctx, immediateSuperior);
+        const schemaSubentry = await getSubschemaSubentry(ctx, immediateSuperior, new Map());
         if (schemaSubentry && (typeof immediateSuperior.dse.governingStructureRule === "number")) {
             if (!schemaSubentry?.dse.subentry) {
                 throw new Error("e41612c3-6239-451f-a971-a9d59bfb5183");

--- a/apps/meerkat/src/app/dop/establishSubordinate.ts
+++ b/apps/meerkat/src/app/dop/establishSubordinate.ts
@@ -321,7 +321,7 @@ async function establishSubordinate (
         newEntryInfo
         && !newEntryInfo.some((info) => info.type_.isEqualTo(governingStructureRule["&id"]))
     ) {
-        const schemaSubentry = await getSubschemaSubentry(ctx, immediateSuperior);
+        const schemaSubentry = await getSubschemaSubentry(ctx, immediateSuperior, new Map());
         if (schemaSubentry && (typeof immediateSuperior.dse.governingStructureRule === "number")) {
             if (!schemaSubentry?.dse.subentry) {
                 throw new Error("e41612c3-6239-451f-a971-a9d59bfb5183");

--- a/apps/meerkat/src/app/dop/operations/establishOperationalBinding.ts
+++ b/apps/meerkat/src/app/dop/operations/establishOperationalBinding.ts
@@ -359,6 +359,7 @@ async function relayedEstablishOperationalBinding (
     relayTo: AccessPoint,
     signErrors: boolean,
 ): Promise<EstablishOperationalBindingResult> {
+    const subentriesCache: Map<number, Vertex[]> = new Map();
     let relay_agreement: ASN1Element | undefined;
     let relay_init: EstablishOperationalBindingArgumentData_initiator | undefined;
     let cp: Vertex | undefined;
@@ -500,6 +501,7 @@ async function relayedEstablishOperationalBinding (
                 {
                     present: invokeId,
                 },
+                subentriesCache,
                 false,
                 signErrors,
             );
@@ -527,6 +529,7 @@ async function relayedEstablishOperationalBinding (
                     {
                         present: invokeId,
                     },
+                    subentriesCache,
                     false,
                     signErrors,
                 );
@@ -1710,6 +1713,7 @@ async function establishOperationalBinding (
                 );
             }
 
+            const subentriesCache: Map<number, Vertex[]> = new Map();
             let structuralObjectClass!: ValidateEntryReturn["structuralObjectClass"];
             let governingStructureRule: ValidateEntryReturn["governingStructureRule"] | undefined;
             try {
@@ -1728,6 +1732,7 @@ async function establishOperationalBinding (
                     {
                         present: invokeId,
                     },
+                    subentriesCache,
                     false,
                     signErrors,
                 );

--- a/apps/meerkat/src/app/x500/validateNewEntry.ts
+++ b/apps/meerkat/src/app/x500/validateNewEntry.ts
@@ -179,6 +179,7 @@ async function validateEntry (
     aliasDereferenced: BOOLEAN,
     manageDSAIT: BOOLEAN,
     invokeId: InvokeId,
+    subentriesCache: Map<number, Vertex[]>,
     tolerateUnknownSchema: boolean = false,
     signErrors: boolean = false,
 ): Promise<ValidateEntryReturn> {
@@ -1061,7 +1062,7 @@ async function validateEntry (
     let governingStructureRule: number | undefined;
     const schemaSubentry = (isSubentry || !immediateSuperior) // Schema rules only apply to entries.
         ? undefined
-        : await getSubschemaSubentry(ctx, immediateSuperior);
+        : await getSubschemaSubentry(ctx, immediateSuperior, subentriesCache);
     if (!isExemptFromSubschema && schemaSubentry && immediateSuperior) { // Schema rules only apply to entries.
         assert(schemaSubentry.dse.subentry);
         assert(immediateSuperior.dse.governingStructureRule !== undefined); // Checked above.

--- a/apps/meerkat/src/assets/static/conformance.md
+++ b/apps/meerkat/src/assets/static/conformance.md
@@ -1,7 +1,7 @@
 # Conformance
 
-In the statements below, the term "Meerkat DSA" refers to version 3.2.3 of
-Meerkat DSA, hence these statements are only claimed for version 3.2.3 of
+In the statements below, the term "Meerkat DSA" refers to version 3.2.4 of
+Meerkat DSA, hence these statements are only claimed for version 3.2.4 of
 Meerkat DSA.
 
 ## X.519 Conformance Statement

--- a/k8s/charts/meerkat-dsa/Chart.yaml
+++ b/k8s/charts/meerkat-dsa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: meerkat-dsa
 description: X.500 Directory Server (DSA) and LDAP Server by Wildboar Software.
 type: application
-version: 2.17.2
+version: 2.17.3
 appVersion: 3.2.4
 home: https://wildboarsoftware.com
 keywords:

--- a/k8s/charts/meerkat-dsa/Chart.yaml
+++ b/k8s/charts/meerkat-dsa/Chart.yaml
@@ -3,7 +3,7 @@ name: meerkat-dsa
 description: X.500 Directory Server (DSA) and LDAP Server by Wildboar Software.
 type: application
 version: 2.17.2
-appVersion: 3.2.3
+appVersion: 3.2.4
 home: https://wildboarsoftware.com
 keywords:
   - directory

--- a/pkg/control
+++ b/pkg/control
@@ -1,5 +1,5 @@
 Package: meerkat-dsa
-Version: 3.2.3
+Version: 3.2.4
 Section: database
 Priority: optional
 Architecture: i386

--- a/pkg/docker-compose.yaml
+++ b/pkg/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     labels:
       author: Wildboar Software
       app: meerkat
-      version: "3.2.3"
+      version: "3.2.4"
     ports:
       - '1389:389/tcp' # LDAP TCP Port
       - '4632:4632/tcp' # IDM Socket

--- a/pkg/meerkat-dsa.rb
+++ b/pkg/meerkat-dsa.rb
@@ -2,7 +2,7 @@ class MeerkatDSA < Formula
     desc "X.500 Directory Server (DSA) and LDAP Server by Wildboar Software"
     homepage "https://github.com/Wildboar-Software/directory"
     url "https://github.com/Wildboar-Software/directory/archive/v1.1.0.tar.gz"
-    version = "3.2.3"
+    version = "3.2.4"
     # sha256 "e86694b2e15d8d4da2477c44e584fb5e860666787d010801199a0a77bcf28a2d"
 
     def install

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: meerkat-dsa
 base: core20
-version: '3.2.3'
+version: '3.2.4'
 summary: X.500 Directory (DSA) and LDAP Server
 description: |
   Fully-featured X.500 directory server / directory system agent (DSA)


### PR DESCRIPTION
This version _doubles_ the speed of inserting new entries by caching
subschema subentries between invocations of the `addEntry` operation.