### PR TITLE
fix: pass in handler to .catch()

### DIFF
--- a/apps/meerkat/src/app/authn/attemptPassword.ts
+++ b/apps/meerkat/src/app/authn/attemptPassword.ts
@@ -420,7 +420,7 @@ async function attemptPassword (
             }
         })
             .then() // INTENTIONAL_NO_AWAIT
-            .catch(); // If we fail, we just let it fail. // TODO: Log this.
+            .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_delete_pwd_lockout", { e }))); // If we fail, we just let it fail.
     }
     const passwordRecentlyExpiredValue = entry_attrs[userPwdRecentlyExpired["&id"].toString()]?.[0];
     const password2 = passwordRecentlyExpiredValue

--- a/apps/meerkat/src/app/dap/DAPConnection.ts
+++ b/apps/meerkat/src/app/dap/DAPConnection.ts
@@ -773,7 +773,8 @@ class DAPAssociation extends ClientAssociation {
         for (const req of this.prebindRequests) {
             // We process these requests serially, just because there could be
             // many of them backed up prior to binding.
-            await handleRequestAndErrors(this.ctx, this, req).catch();
+            await handleRequestAndErrors(this.ctx, this, req)
+                .catch((e) => console.error(e)); // This should never really happen.
         }
     }
 
@@ -788,7 +789,8 @@ class DAPAssociation extends ClientAssociation {
      * @function
      */
     private handleRequest (request: RequestParameters): void {
-        handleRequestAndErrors(this.ctx, this, request).catch();
+        handleRequestAndErrors(this.ctx, this, request)
+            .catch((e) => console.error(e)); // This should never really happen.
     }
 
     public reset (): void {
@@ -800,12 +802,12 @@ class DAPAssociation extends ClientAssociation {
             where: {
                 connection_uuid: this.id,
             },
-        }).then().catch();
+        }).then().catch(() => {});
         this.ctx.db.enqueuedSearchResult.deleteMany({ // INTENTIONAL_NO_AWAIT
             where: {
                 connection_uuid: this.id,
             },
-        }).then().catch();
+        }).then().catch(() => {});
     }
 
     /**

--- a/apps/meerkat/src/app/database/drivers/attributeTypes.ts
+++ b/apps/meerkat/src/app/database/drivers/attributeTypes.ts
@@ -236,7 +236,10 @@ const addValue: SpecialAttributeDatabaseEditor = async (
                 select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
             })
                 .then()
-                .catch(); // TODO: Log something.
+                .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_save@attr_type", { oid: OID, e }), {
+                    oid: OID,
+                    e,
+                }));
 
             /**
              * You cannot specify an LDAP syntax or a validator, so we have to infer

--- a/apps/meerkat/src/app/database/drivers/contextTypes.ts
+++ b/apps/meerkat/src/app/database/drivers/contextTypes.ts
@@ -187,7 +187,10 @@ const addValue: SpecialAttributeDatabaseEditor = async (
                 select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
             })
                 .then()
-                .catch(); // TODO: Log something.
+                .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_save@context_type", { oid: OID, e }), {
+                    oid: OID,
+                    e,
+                }));
             const info: ContextTypeInfo = {
                 id: decoded.identifier,
                 name: names,

--- a/apps/meerkat/src/app/database/drivers/nameForms.ts
+++ b/apps/meerkat/src/app/database/drivers/nameForms.ts
@@ -177,7 +177,10 @@ const addValue: SpecialAttributeDatabaseEditor = async (
                 select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
             })
                 .then()
-                .catch(); // TODO: Log something.
+                .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_save@name_form", { oid: OID, e }), {
+                    oid: OID,
+                    e,
+                }));
             const info: NameFormInfo = {
                 id: decoded.identifier,
                 name: names,

--- a/apps/meerkat/src/app/database/drivers/objectClasses.ts
+++ b/apps/meerkat/src/app/database/drivers/objectClasses.ts
@@ -207,8 +207,10 @@ const addValue: SpecialAttributeDatabaseEditor = async (
                 select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
             })
                 .then()
-                .catch(); // TODO: Log something.
-
+                .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_save@objet_class", { oid: OID, e }), {
+                    oid: OID,
+                    e,
+                }));
             const info: ObjectClassInfo = {
                 id: decoded.identifier,
                 name: decoded.name?.map(directoryStringToString),

--- a/apps/meerkat/src/app/disp/DISPConnection.ts
+++ b/apps/meerkat/src/app/disp/DISPConnection.ts
@@ -684,7 +684,8 @@ class DISPAssociation extends ClientAssociation {
         for (const req of this.prebindRequests) {
             // We process these requests serially, just because there could be
             // many of them backed up prior to binding.
-            await handleRequestAndErrors(this.ctx, this, req).catch();
+            await handleRequestAndErrors(this.ctx, this, req)
+                .catch((e) => console.error(e)); // This should never really happen.
         }
     }
 
@@ -713,12 +714,12 @@ class DISPAssociation extends ClientAssociation {
             where: {
                 connection_uuid: this.id,
             },
-        }).then().catch();
+        }).catch(() => {});
         this.ctx.db.enqueuedSearchResult.deleteMany({ // INTENTIONAL_NO_AWAIT
             where: {
                 connection_uuid: this.id,
             },
-        }).then().catch();
+        }).catch(() => {});
     }
 
     /**

--- a/apps/meerkat/src/app/distributed/addEntry.ts
+++ b/apps/meerkat/src/app/distributed/addEntry.ts
@@ -1398,7 +1398,9 @@ async function addEntry (
                     accepted: false,
                 },
                 select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
-            }).then().catch();
+            })
+                .then()
+                .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_cancel_ob"), e));
             throw e;
         }
         /**
@@ -1419,7 +1421,9 @@ async function addEntry (
                     accepted: false,
                 },
                 select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
-            }).then().catch();
+            })
+                .then()
+                .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_cancel_ob"), e));
             throw new errors.UnknownError(ctx.i18n.t("err:could_not_find_new_subr"));
         }
         await ctx.db.operationalBinding.update({
@@ -1719,7 +1723,7 @@ async function addEntry (
                     governingStructureRule: Number(structuralRuleThatAppliesToImmediateSuperior.ruleIdentifier),
                 },
                 select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
-            }).catch(); // TODO: Log
+            }).catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_update_gsr"), e));
         }
     }
 

--- a/apps/meerkat/src/app/distributed/hierarchySelection.ts
+++ b/apps/meerkat/src/app/distributed/hierarchySelection.ts
@@ -149,7 +149,6 @@ async function id_to_dn (
     let current_id: number | null = id;
     const dn: DistinguishedName = [];
     while (current_id) {
-        console.log(current_id);
         const cached = rdnsById.get(current_id);
         if (cached) {
             const [ superior_id, rdn ] = cached;

--- a/apps/meerkat/src/app/distributed/removeEntry.ts
+++ b/apps/meerkat/src/app/distributed/removeEntry.ts
@@ -588,7 +588,7 @@ async function removeEntry (
     /** Remove the `hierarchyParent` attribute so hierarchical children are updated */
     ctx.db.$transaction(await removeAttribute(ctx, target, hierarchyParent["&id"]))
         .then()
-        .catch();
+        .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_remove_hp"), e));
     await deleteEntry(ctx, target, alsoDeleteFamily);
 
     if (target.dse.subentry) {

--- a/apps/meerkat/src/app/dop/DOPConnection.ts
+++ b/apps/meerkat/src/app/dop/DOPConnection.ts
@@ -783,7 +783,8 @@ class DOPAssociation extends ClientAssociation {
         for (const req of this.prebindRequests) {
             // We process these requests serially, just because there could be
             // many of them backed up prior to binding.
-            await handleRequestAndErrors(this.ctx, this, req).catch();
+            await handleRequestAndErrors(this.ctx, this, req)
+                .catch((e) => console.error(e)); // This should never really happen.
         }
     }
 
@@ -812,12 +813,12 @@ class DOPAssociation extends ClientAssociation {
             where: {
                 connection_uuid: this.id,
             },
-        }).then().catch();
+        }).then().catch(() => {});
         this.ctx.db.enqueuedSearchResult.deleteMany({ // INTENTIONAL_NO_AWAIT
             where: {
                 connection_uuid: this.id,
             },
-        }).then().catch();
+        }).then().catch(() => {});
     }
 
     /**

--- a/apps/meerkat/src/app/dop/establishSubordinate.ts
+++ b/apps/meerkat/src/app/dop/establishSubordinate.ts
@@ -421,7 +421,9 @@ async function establishSubordinate (
             key: ctx.config.signing.key,
         };
         const response = await assn.establishHOBWithSubordinate(opts);
-        assn.unbind().then().catch(); // INTENTIONAL_NO_AWAIT
+        assn.unbind() // INTENTIONAL_NO_AWAIT
+            .then()
+            .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_unbind"), e));
         if ("result" in response && response.result) {
             const result = response.result.parameter;
             if ("signed" in result) {

--- a/apps/meerkat/src/app/dop/operations/establishOperationalBinding.ts
+++ b/apps/meerkat/src/app/dop/operations/establishOperationalBinding.ts
@@ -273,10 +273,8 @@ async function modifySOB_delete_me (
         });
     dop.unbind();
     if (!("result" in outcome)) {
-        console.error(outcome);
         return;
     }
-    console.log("MODIFIED SOB");
     const agr_el = _encode_ShadowingAgreementInfo(newAgreement, DER).toBytes();
 
     const { id } = await ctx.db.operationalBinding.create({
@@ -1916,7 +1914,9 @@ async function establishOperationalBinding (
                             last_ob_problem: e.data.problem,
                         },
                         select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
-                    }).then().catch();
+                    })
+                        .then()
+                        .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_cancel_ob"), e));
                 } else {
                     ctx.db.operationalBinding.update({
                         where: {
@@ -1926,7 +1926,9 @@ async function establishOperationalBinding (
                             accepted: false,
                         },
                         select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
-                    }).then().catch();
+                    })
+                        .then()
+                        .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_cancel_ob"), e));
                 }
                 throw e;
             }
@@ -2106,7 +2108,9 @@ async function establishOperationalBinding (
                             last_ob_problem: e.data.problem,
                         },
                         select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
-                    }).then().catch();
+                    })
+                        .then()
+                        .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_cancel_ob"), e));
                 } else {
                     ctx.db.operationalBinding.update({
                         where: {
@@ -2116,7 +2120,9 @@ async function establishOperationalBinding (
                             accepted: false,
                         },
                         select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
-                    }).then().catch();
+                    })
+                        .then()
+                        .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_cancel_ob"), e));
                 }
                 throw e;
             }
@@ -2327,6 +2333,7 @@ async function establishOperationalBinding (
                     uuid: created.uuid,
                     e,
                 }));
+                // TODO: These error handling sections are all duplicated. You could deduplicate them.
                 if (e instanceof errors.OperationalBindingError) {
                     ctx.db.operationalBinding.update({
                         where: {
@@ -2337,7 +2344,9 @@ async function establishOperationalBinding (
                             last_ob_problem: e.data.problem,
                         },
                         select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
-                    }).then().catch();
+                    })
+                        .then()
+                        .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_cancel_ob"), e));
                 } else {
                     ctx.db.operationalBinding.update({
                         where: {
@@ -2347,7 +2356,9 @@ async function establishOperationalBinding (
                             accepted: false,
                         },
                         select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
-                    }).then().catch();
+                    })
+                        .then()
+                        .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_cancel_ob"), e));
                 }
                 throw e;
             }
@@ -2536,7 +2547,9 @@ async function establishOperationalBinding (
                             last_ob_problem: e.data.problem,
                         },
                         select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
-                    }).then().catch();
+                    })
+                        .then()
+                        .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_cancel_ob"), e));
                 } else {
                     ctx.db.operationalBinding.update({
                         where: {
@@ -2546,7 +2559,9 @@ async function establishOperationalBinding (
                             accepted: false,
                         },
                         select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
-                    }).then().catch();
+                    })
+                        .then()
+                        .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_cancel_ob"), e));
                 }
                 throw e;
             }
@@ -2887,7 +2902,9 @@ async function establishOperationalBinding (
                             last_ob_problem: e.data.problem,
                         },
                         select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
-                    }).then().catch();
+                    })
+                        .then()
+                        .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_cancel_ob"), e));
                 } else {
                     ctx.db.operationalBinding.update({
                         where: {
@@ -2897,7 +2914,9 @@ async function establishOperationalBinding (
                             accepted: false,
                         },
                         select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
-                    }).then().catch();
+                    })
+                        .then()
+                        .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_cancel_ob"), e));
                 }
                 throw e;
             }
@@ -3089,7 +3108,9 @@ async function establishOperationalBinding (
                             last_ob_problem: e.data.problem,
                         },
                         select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
-                    }).then().catch();
+                    })
+                        .then()
+                        .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_cancel_ob"), e));
                 } else {
                     ctx.db.operationalBinding.update({
                         where: {
@@ -3099,7 +3120,9 @@ async function establishOperationalBinding (
                             accepted: false,
                         },
                         select: { id: true }, // UNNECESSARY See: https://github.com/prisma/prisma/issues/6252
-                    }).then().catch();
+                    })
+                        .then()
+                        .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_cancel_ob"), e));
                 }
                 throw e;
             }

--- a/apps/meerkat/src/app/dop/terminateByID.ts
+++ b/apps/meerkat/src/app/dop/terminateByID.ts
@@ -67,7 +67,7 @@ async function terminate (
             if (iAmSuperior) {
                 removeSubordinate(ctx, agreement)
                     .then()
-                    .catch()
+                    .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_remove_subordinate"), e))
                     ; // Async, but we do not need to await.
             }
             /*

--- a/apps/meerkat/src/app/dop/updateHOBSubordinateDSA.ts
+++ b/apps/meerkat/src/app/dop/updateHOBSubordinateDSA.ts
@@ -413,7 +413,9 @@ async function updateHOBSubordinateDSA (
             problem: response,
         }), logInfo);
     }
-    assn.unbind().catch(); // INTENTIONAL NO AWAIT
+    assn
+        .unbind() // INTENTIONAL NO AWAIT
+        .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_unbind"), e));
 }
 
 export default updateHOBSubordinateDSA;

--- a/apps/meerkat/src/app/dop/updateNHOBSubordinateDSA.ts
+++ b/apps/meerkat/src/app/dop/updateNHOBSubordinateDSA.ts
@@ -404,7 +404,9 @@ async function updateNHOBSubordinateDSA (
             problem: response,
         }), logInfo);
     }
-    assn.unbind().catch(); // INTENTIONAL NO AWAIT
+    assn
+        .unbind() // INTENTIONAL NO AWAIT
+        .catch((e) => ctx.log.error(ctx.i18n.t("log:failed_to_unbind"), e));
 }
 
 export default updateNHOBSubordinateDSA;

--- a/apps/meerkat/src/app/dsp/DSPConnection.ts
+++ b/apps/meerkat/src/app/dsp/DSPConnection.ts
@@ -730,7 +730,8 @@ class DSPAssociation extends ClientAssociation {
         for (const req of this.prebindRequests) {
             // We process these requests serially, just because there could be
             // many of them backed up prior to binding.
-            await handleRequestAndErrors(this.ctx, this, req).catch();
+            await handleRequestAndErrors(this.ctx, this, req)
+                .catch((e) => console.error(e)); // This should never really happen.
         }
     }
 
@@ -757,12 +758,12 @@ class DSPAssociation extends ClientAssociation {
             where: {
                 connection_uuid: this.id,
             },
-        }).then().catch();
+        }).then().catch(() => {});
         this.ctx.db.enqueuedSearchResult.deleteMany({ // INTENTIONAL_NO_AWAIT
             where: {
                 connection_uuid: this.id,
             },
-        }).then().catch();
+        }).then().catch(() => {});
     }
 
     /**

--- a/apps/meerkat/src/app/ldap/LDAPConnection.ts
+++ b/apps/meerkat/src/app/ldap/LDAPConnection.ts
@@ -565,12 +565,12 @@ class LDAPAssociation extends ClientAssociation {
             where: {
                 connection_uuid: this.id,
             },
-        }).then().catch();
+        }).then().catch(() => {});
         this.ctx.db.enqueuedListResult.deleteMany({
             where: {
                 connection_uuid: this.id,
             },
-        }).then().catch();
+        }).then().catch(() => {});
     }
 
     /**

--- a/apps/meerkat/src/app/main.ts
+++ b/apps/meerkat/src/app/main.ts
@@ -1135,8 +1135,8 @@ async function main (): Promise<void> {
         cwd: process.cwd(),
     }));
 
-    ctx.db.enqueuedListResult.deleteMany().then().catch();
-    ctx.db.enqueuedSearchResult.deleteMany().then().catch();
+    ctx.db.enqueuedListResult.deleteMany().then().catch(() => {});
+    ctx.db.enqueuedSearchResult.deleteMany().then().catch(() => {});
 
     const signingCertPath = ctx.config.signing.certPath;
 
@@ -1386,7 +1386,7 @@ async function main (): Promise<void> {
     ctx.log.info(ctx.i18n.t("log:docs"));
 
     if (versionSlug) {
-        checkForUpdates(ctx, versionSlug).catch();
+        checkForUpdates(ctx, versionSlug).catch(() => {});
     }
 
     if (ctx.config.bulkInsertMode) {
@@ -1397,7 +1397,7 @@ async function main (): Promise<void> {
 
     setInterval(() => {
         const dbReportPromise = createDatabaseReport(ctx);
-        dbReportPromise.catch();
+        dbReportPromise.catch(() => {});
         dbReportPromise.then((report) => {
             ctx.telemetry.trackEvent({
                 name: "dbreport",
@@ -1409,7 +1409,7 @@ async function main (): Promise<void> {
                     administratorEmail: ctx.config.administratorEmail,
                 },
             });
-        }).catch(); // This handles the new promise returned by .then().
+        }).catch(() => {}); // This handles the new promise returned by .then().
     }, 604_800_000); // Weekly
 
     /**

--- a/apps/meerkat/src/app/pki/curl.ts
+++ b/apps/meerkat/src/app/pki/curl.ts
@@ -396,6 +396,8 @@ async function curlFTP (
         return null;
     } finally {
         client.close();
-        rm(localFilePath).then().catch(); // Errors are just ignored.
+        rm(localFilePath)
+            .then()
+            .catch((e) => console.error(e));
     }
 }

--- a/apps/meerkat/src/app/service/general_check_of_search_filter.ts
+++ b/apps/meerkat/src/app/service/general_check_of_search_filter.ts
@@ -159,7 +159,6 @@ export function general_check_of_search_filter(
         ("and" in rule.attributeCombination)
         && (rule.attributeCombination.and.length === 0)
     )) {
-        console.log(rule.attributeCombination);
         state.missingSearchAttributes.push(...Array
             .from(required_attrs.values())
             .map((s) => ObjectIdentifier.fromString(s)));

--- a/apps/meerkat/src/assets/locales/en/language/log.json
+++ b/apps/meerkat/src/assets/locales/en/language/log.json
@@ -411,5 +411,15 @@
     "reverse_dsa_bind_auth_fail": "Reverse DSA bind credentials are invalid: {{e}}",
     "reverse_dsa_bind_other_err": "Reverse DSA bind failed: {{e}}",
     "reverse_dsa_bind_auth_required": "The DSA bind result did not include credentials, but the local DSA requires mutual authentication.",
-    "reverse_dsa_bind_auth_optional": "Reverse DSA bind credentials were not supplied or invalid, but the local DSA is configured to ignore this."
+    "reverse_dsa_bind_auth_optional": "Reverse DSA bind credentials were not supplied or invalid, but the local DSA is configured to ignore this.",
+    "failed_to_delete_pwd_lockout": "Failed to delete pwdLockout and pwdAccountLockedTime attributes: {{e}}",
+    "failed_to_save@attr_type": "Failed to save attribute type definition {{oid}} to database: {{e}}",
+    "failed_to_save@object_class": "Failed to save object class definition {{oid}} to database: {{e}}",
+    "failed_to_save@context_type": "Failed to save context type definition to database: {{e}}",
+    "failed_to_save@name_form": "Failed to save name_form definition to {{oid}} database: {{e}}",
+    "failed_to_cancel_ob": "Failed to mark operational binding as rejected in response to error: ",
+    "failed_to_update_gsr": "Failed to update governing structure rule for immediate superior: ",
+    "failed_to_remove_hp": "Failed to remove hierarchyParent attribute from deleted entry: ",
+    "failed_to_unbind": "Failed to unbind: ",
+    "failed_to_remove_subordinate": "Failed to remove subordinate DSE: "
 }

--- a/libs/x500-functional-tests/src/tests/server.spec.ts
+++ b/libs/x500-functional-tests/src/tests/server.spec.ts
@@ -489,7 +489,6 @@ describe.skip("Meerkat DSA", () => {
     // Manual-testing only.
     it.skip("The DSA refuses an excessive number of connections from the same remote address", async () => {
         for (let i = 0; i < 100; i++) {
-            console.log(i);
             net.createConnection({
                 host: HOST,
                 port: PORT,
@@ -1012,7 +1011,7 @@ describe.skip("Meerkat DSA", () => {
             idm!,
             read["&operationCode"]!,
             _encode_ReadArgument(arg, DER),
-        ).catch();
+        ).catch((e) => console.error(e));
         idm.close();
         expect(connect()).resolves.toBeTruthy();
     });


### PR DESCRIPTION
I didn't know that an empty .catch() would do nothing! I specifically used .catch() to ignore errors. Now, I log most of them.